### PR TITLE
Melhorias no uso do docker com xdebug

### DIFF
--- a/Dockerfile-1.7
+++ b/Dockerfile-1.7
@@ -10,7 +10,7 @@ ENV CERT_KEY_PATH=$cert_key_path
 RUN apt update && apt install -y vim
 
 # XDEBUG
-RUN pecl install xdebug
+RUN pecl install xdebug-3.1.6
 RUN echo zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so >> /usr/local/etc/php/php.ini
 
 # APACHE

--- a/Dockerfile-8
+++ b/Dockerfile-8
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:nightly-8.1-apache
+FROM prestashop/prestashop:8.1-apache
 
 ARG cert_path
 ENV CERT_PATH=$cert_path
@@ -9,8 +9,9 @@ ENV CERT_KEY_PATH=$cert_key_path
 RUN apt update && apt install -y vim
 
 # XDEBUG
-RUN pecl install xdebug
-RUN echo zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so >> /usr/local/etc/php/php.ini
+RUN pecl install xdebug-3.1.6 \
+      && docker-php-ext-enable xdebug
+RUN echo zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so >> /usr/local/etc/php/php.ini
 
 # APACHE
 COPY apache/default.conf /etc/apache2/sites-available/000-default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     volumes:
       - ./src:/var/www/html
       - ./php/php.ini:/usr/local/etc/php/php.ini
-      - ./mercadopago:/var/www/html/modules/mercadopago
       - ${CERT_PATH}:/certs/cert.pem
       - ${CERT_KEY_PATH}:/certs/cert.key
     networks:

--- a/readme.md
+++ b/readme.md
@@ -42,19 +42,28 @@ To run XDebug you need to set the path mappings.\
 
 ### VSCODE
 > 1 - Install de official Xdebug extension. Serach for: `xdebug.php-debug`\
-> 2 - On the top menu click on `Run` then `Add configuration` then select `PHP`\
+> 2 - Go to the `src/modules/mercadopago` folder, on the top menu click on `Run` then `Add configuration` then select `PHP`\
 > 3 - Put the following config on the list:
 > ```
 > {
->   "name": "Listen for Prestashop Docker XDebug",
->   "type": "php",
->   "request": "launch",
->   "port": 9003,
->   "pathMappings": {
->       "/var/www/html": "${workspaceRoot}/src",
->       "/var/www/html/modules/mercadopago": "${workspaceRoot}/mercadopago",
->   },
->   "log": true
-> },
-> 4 - Then on the run tab click `Run`
+>    "version": "0.2.0",
+>    "configurations": [
+>        {
+>            "name": "Debug",
+>            "type": "php",
+>            "request": "launch",
+>            "port": 9003,
+>            "pathMappings": {
+>                "/var/www/html/modules/mercadopago": "${workspaceRoot}",
+>            },
+>            "log": true,
+>            "xdebugSettings": {
+>                "max_data": -1,
+>                "max_children": 128,
+>                "max_depth": 5
+>            },
+>          },
+>    ]
+> }
 > ```
+> 4 - Then on the run tab click `Run`


### PR DESCRIPTION
### Descrição
Durante o desenvolvimento no Prestashop 1.7 e 8.x, identificamos algumas oportunidades de melhorias na configuração dos arquivos do Docker, especificamente para trabalhar com o xdebug.

Dito isso, essa PR faz algumas alterações que fixa a versão do xdebug e atualizar algumas coonfigs.